### PR TITLE
fix time format bugs on slim screen

### DIFF
--- a/_includes/_partial/post/header.html
+++ b/_includes/_partial/post/header.html
@@ -4,14 +4,11 @@
       <a href="{{ item.link }}" target="_blank" title="{{ item.title }}">{{ item.title }}</a>{% else %}
       <a href="{{ site.baseurl }}{{ item.url }}" title="{{ item.title }}" itemprop="url">{{ item.title }}</a>{% endif %}
   </h1>
-  <p class="article-author">By
-       {% if site.author.google_plus %}
+  <p class="article-author">By: {% if site.author.google_plus %}
 		<a href="https://plus.google.com/{{ site.author.google_plus }}?rel=author" title="{{ site.author.name }}" target="_blank" itemprop="author">{{ site.author.name }}</a>
 		{% else %}
 		<a href="{{ site.baseurl }}/about" title="{{ site.author.name }}" target="_blank" itemprop="author">{{ site.author.name }}</a>
 		{% endif %}
-  <p class="article-time">
-    <time datetime="{{ item.date }}" itemprop="datePublished"> {{ lang.datepublished }} {{ item.date | date: "%F" }}</time>
-    
+    <time datetime="{{ item.date }}" itemprop="datePublished">  • {{ lang.datepublished }} {{ item.date | date: "%F" }}</time>
   </p>
 </header>


### PR DESCRIPTION
博客文章的时间信息在窄屏幕（例如手机屏幕）上会错位，影响首页和博客全文页。该bug已修复。
修复前：
![image](https://user-images.githubusercontent.com/5274450/28414774-add25f72-6d7f-11e7-93e1-581aed902b41.png)
修复后：
![image](https://user-images.githubusercontent.com/5274450/28414842-e299c678-6d7f-11e7-9f19-c09d933d91d3.png)

